### PR TITLE
Compute capital gains using FIFO model for FHorz agents

### DIFF
--- a/OLGModel14.m
+++ b/OLGModel14.m
@@ -257,15 +257,15 @@ AgeConditionalStats=LifeCycleProfiles_FHorz_Case1_PType(StationaryDist,Policy,Fn
 Params.S_agej_first=max(find(AgeConditionalStats.household.Mean>0.1,1,'first')-1,1);
 Params.S_agej_last=min(find(AgeConditionalStats.household.Mean>0.5,1,'last')+1,length(AgeConditionalStats.household.Mean)); % warmglow creates extra long tail we want to ignore
 [~,S_agej_peak]=max(AgeConditionalStats.household.Mean);
-S_peak_inflection_value=(1-1/Params.J)*AgeConditionalStats.household.Mean(S_agej_peak);
+S_peak_inflection_value=0.95*AgeConditionalStats.household.Mean(S_agej_peak);
 for S_agej_peak_first=S_agej_peak:-1:Params.S_agej_first
-    if AgeConditionalStats.household.Mean(Params.S_agej_peak_first)<S_peak_inflection_value
+    if AgeConditionalStats.household.Mean(S_agej_peak_first)<S_peak_inflection_value
         break
     end
 end
 Params.S_agej_peak_first=S_agej_peak_first;
-for S_agej_peak_last=Params.S_agej_last:-1:S_agej_peak
-    if AgeConditionalStats.household.Mean(Params.S_agej_peak_last-1)>S_peak_inflection_value
+for S_agej_peak_last=S_agej_peak:Params.S_agej_last
+    if AgeConditionalStats.household.Mean(S_agej_peak_last)<S_peak_inflection_value
         break
     end
 end

--- a/OLGModel14.m
+++ b/OLGModel14.m
@@ -203,7 +203,7 @@ ReturnFn.firm=@(d,kprime,k,z,w,D,delta,alpha_k,alpha_l,capadjconstant,tau_corp,p
 disp('Test ValueFnIter')
 tic;
 % Note: z_grid and pi_z, this will be ignored due to presence of vfoptions.z_grid_J and vfoptions.pi_z_J
-[V, Policy]=ValueFnIter_Case1_FHorz_PType(n_d,n_a,n_z,N_j,Names_i, d_grid, a_grid, z_grid, pi_z, ReturnFn, Params, DiscountFactorParamNames, vfoptions);
+[V, Policy]=ValueFnIter_MixHorz_PType(n_d,n_a,n_z,N_j,Names_i, d_grid, a_grid, z_grid, pi_z, ReturnFn, Params, DiscountFactorParamNames, vfoptions);
 toc
 
 %% Initial distribution of agents at birth (j=1)
@@ -227,7 +227,7 @@ AgeWeightsParamNames={'mewj'}; % So VFI Toolkit knows which parameter is the mas
 
 %% Test
 disp('Test StationaryDist')
-StationaryDist=StationaryDist_Case1_FHorz_PType(jequaloneDist,AgeWeightsParamNames,PTypeDistParamNames,Policy,n_d,n_a,n_z,N_j,Names_i,pi_z,Params,simoptions);
+StationaryDist=StationaryDist_MixHorz_PType(jequaloneDist,AgeWeightsParamNames,PTypeDistParamNames,Policy,n_d,n_a,n_z,N_j,Names_i,pi_z,Params,simoptions);
 
 %% General eqm variables
 GEPriceParamNames={'pension','G','w','firmbeta','D','P0'}; 
@@ -253,7 +253,7 @@ FnsToEvaluate.AccidentalBeq.household = @(h,sprime,s,z,e,agej,sj,n,P0,r,tau_cg,S
     (sprime-OLGModel14_HouseholdCapitalGainsFn(h,sprime,s,z,e,agej,1,P0,0,r,tau_cg,S_agej_first,S_agej_peak_first,S_agej_peak_last,S_agej_last))*(1-sj)/(1+n);
 FnsToEvaluate.CapitalGainsTaxRevenue.household = @(h,sprime,s,z,e,agej,P0,AccidentBeq,r,tau_cg,S_agej_first,S_agej_peak_first,S_agej_peak_last,S_agej_last) OLGModel14_HouseholdCapitalGainsFn(h,sprime,s,z,e,agej,0,P0,AccidentBeq,r,tau_cg,S_agej_first,S_agej_peak_first,S_agej_peak_last,S_agej_last);
 
-AgeConditionalStats=LifeCycleProfiles_FHorz_Case1_PType(StationaryDist,Policy,FnsToEvaluate.S,Params,n_d,n_a,n_z,N_j,Names_i,d_grid,a_grid,z_grid,simoptions);
+AgeConditionalStats=LifeCycleProfiles_MixHorz_PType(StationaryDist,Policy,FnsToEvaluate.S,Params,n_d,n_a,n_z,N_j,Names_i,d_grid,a_grid,z_grid,simoptions);
 Params.S_agej_first=max(find(AgeConditionalStats.household.Mean>0.1,1,'first')-1,1);
 Params.S_agej_last=min(find(AgeConditionalStats.household.Mean>0.5,1,'last')+1,length(AgeConditionalStats.household.Mean)); % warmglow creates extra long tail we want to ignore
 [~,S_agej_peak]=max(AgeConditionalStats.household.Mean);
@@ -293,7 +293,7 @@ GeneralEqmEqns.CapitalOutputRatio =@(K,L_f,TargetKdivL) K/L_f-TargetKdivL;
 %% Test
 % Note: Because we used simoptions we must include this as an input
 disp('Test AggVars')
-AggVars=EvalFnOnAgentDist_AggVars_FHorz_Case1_PType(StationaryDist, Policy, FnsToEvaluate, Params, n_d, n_a, n_z,N_j,Names_i, d_grid, a_grid, z_grid,simoptions);
+AggVars=EvalFnOnAgentDist_AggVars_MixHorz_Case1_PType(StationaryDist, Policy, FnsToEvaluate, Params, n_d, n_a, n_z,N_j,Names_i, d_grid, a_grid, z_grid,simoptions);
 
 % Next few lines were used to try a few parameter values so as to get a
 % decent initial guess before actually solving the general equilbrium
@@ -313,7 +313,7 @@ Params.AccidentBeq=AggVars.AccidentalBeq.household.Mean;
 % heteroagentoptions.fminalgo=4 % CMA-ES algorithm 
 
 heteroagentoptions.verbose=1;
-p_eqm=HeteroAgentStationaryEqm_Case1_FHorz_PType(n_d, n_a, n_z, N_j, Names_i, [], pi_z, d_grid, a_grid, z_grid,jequaloneDist, ReturnFn, FnsToEvaluate, GeneralEqmEqns, Params, DiscountFactorParamNames, AgeWeightsParamNames, PTypeDistParamNames, GEPriceParamNames,heteroagentoptions, simoptions, vfoptions);
+p_eqm=HeteroAgentStationaryEqm_MixHorz_PType(n_d, n_a, n_z, N_j, Names_i, [], pi_z, d_grid, a_grid, z_grid,jequaloneDist, ReturnFn, FnsToEvaluate, GeneralEqmEqns, Params, DiscountFactorParamNames, AgeWeightsParamNames, PTypeDistParamNames, GEPriceParamNames,heteroagentoptions, simoptions, vfoptions);
 % p_eqm contains the general equilibrium parameter values
 % Put this into Params so we can calculate things about the initial equilibrium
 Params.pension=p_eqm.pension;
@@ -325,10 +325,10 @@ Params.D=p_eqm.D;
 Params.P0=p_eqm.P0;
 
 % Calculate a few things related to the general equilibrium.
-[V, Policy]=ValueFnIter_Case1_FHorz_PType(n_d,n_a,n_z,N_j, Names_i, d_grid, a_grid, z_grid, pi_z, ReturnFn, Params, DiscountFactorParamNames, vfoptions);
-StationaryDist=StationaryDist_Case1_FHorz_PType(jequaloneDist,AgeWeightsParamNames,PTypeDistParamNames,Policy,n_d,n_a,n_z,N_j,Names_i,pi_z,Params,simoptions);
+[V, Policy]=ValueFnIter_MixHorz_PType(n_d,n_a,n_z,N_j, Names_i, d_grid, a_grid, z_grid, pi_z, ReturnFn, Params, DiscountFactorParamNames, vfoptions);
+StationaryDist=StationaryDist_MixHorz_PType(jequaloneDist,AgeWeightsParamNames,PTypeDistParamNames,Policy,n_d,n_a,n_z,N_j,Names_i,pi_z,Params,simoptions);
 % Can just use the same FnsToEvaluate as before.
-AgeConditionalStats=LifeCycleProfiles_FHorz_Case1_PType(StationaryDist,Policy,FnsToEvaluate,Params,n_d,n_a,n_z,N_j,Names_i,d_grid,a_grid,z_grid,simoptions);
+AgeConditionalStats=LifeCycleProfiles_MixHorz_PType(StationaryDist,Policy,FnsToEvaluate,Params,n_d,n_a,n_z,N_j,Names_i,d_grid,a_grid,z_grid,simoptions);
 
 %% Plot the life cycle profiles of capital and labour for the inital and final eqm.
 
@@ -345,7 +345,7 @@ title('Life Cycle Profile: Share holdings')
 FnsToEvaluate.Consumption.household=@(h,sprime,s,z,e,agej,Jr,pension,w,P0,D,kappa_j,AccidentBeq,r,tau_l,tau_d,tau_cg,S_agej_first,S_agej_peak_first,S_agej_peak_last,S_agej_last) OLGModel14_HouseholdConsumptionFn(h,sprime,s,z,e,agej,Jr,pension,w,P0,D,kappa_j,AccidentBeq,r,tau_l,tau_d,tau_cg,S_agej_first,S_agej_peak_first,S_agej_peak_last,S_agej_last);
 FnsToEvaluate.Income.household=@(h,sprime,s,z,e,agej,Jr,pension,w,P0,D,kappa_j,AccidentBeq,r,tau_l,tau_d,tau_cg,S_agej_first,S_agej_peak_first,S_agej_peak_last,S_agej_last) OLGModel14_HouseholdIncomeFn(h,sprime,s,z,e,agej,Jr,pension,w,P0,D,kappa_j,AccidentBeq,r,tau_l,tau_d,tau_cg,S_agej_first,S_agej_peak_first,S_agej_peak_last,S_agej_last);
 
-AggVars=EvalFnOnAgentDist_AggVars_FHorz_Case1_PType(StationaryDist, Policy, FnsToEvaluate, Params, n_d, n_a, n_z,N_j, Names_i, d_grid, a_grid, z_grid,simoptions);
+AggVars=EvalFnOnAgentDist_AggVars_MixHorz_Case1_PType(StationaryDist, Policy, FnsToEvaluate, Params, n_d, n_a, n_z,N_j, Names_i, d_grid, a_grid, z_grid,simoptions);
 
 Y=AggVars.Output.Mean;
 

--- a/OLGModel14.m
+++ b/OLGModel14.m
@@ -133,8 +133,13 @@ Params.AccidentBeq=0.02; % Accidental bequests (this is the lump sum transfer)
 Params.G=0.1; % Government expenditure
 Params.firmbeta=1/(1+Params.r/(1-Params.tau_cg)); % 1/(1+r) but returns net of capital gains tax
 Params.D=0.2; % Dividends rate expected/received by households
-Params.P0=1;
-Params.Lhscale=0.21; % Scaling the household labor supply
+Params.P0=2.22; % This price is not 1 because we need price for older and younger agents to balance
+Params.Lhscale=0.22; % Scaling the household labor supply
+
+% We build a simple model of acquiring and disposing of stock over a lifetime
+Params.S_agej_first=20; % the age at which we start acquiring more stock than noise
+Params.S_agej_peak=Params.Jr+1; % the age of peak acquisition
+Params.S_agej_last=Params.J-10; % the age of final disposal
 
 %% Grids for household
 
@@ -184,8 +189,8 @@ z_grid.firm=exp(z_grid.firm);
 % For households
 DiscountFactorParamNames.household={'beta','sj'};
 % Notice we use 'OLGModel14_HouseholdReturnFn'
-ReturnFn.household=@(h,sprime,s,z,e,sigma,psi,eta,agej,Jr,J,pension,w,P0,D,kappa_j,warmglow1,warmglow2,AccidentBeq,r,tau_l,tau_d,tau_cg)...
-    OLGModel14_HouseholdReturnFn(h,sprime,s,z,e,sigma,psi,eta,agej,Jr,J,pension,w,P0,D,kappa_j,warmglow1,warmglow2,AccidentBeq,r,tau_l,tau_d,tau_cg);
+ReturnFn.household=@(h,sprime,s,z,e,sigma,psi,eta,agej,Jr,J,pension,w,P0,D,kappa_j,warmglow1,warmglow2,AccidentBeq,r,tau_l,tau_d,tau_cg,S_agej_first,S_agej_peak,S_agej_last)...
+    OLGModel14_HouseholdReturnFn(h,sprime,s,z,e,sigma,psi,eta,agej,Jr,J,pension,w,P0,D,kappa_j,warmglow1,warmglow2,AccidentBeq,r,tau_l,tau_d,tau_cg,S_agej_first,S_agej_peak,S_agej_last);
 
 % For firms
 DiscountFactorParamNames.firm={'firmbeta'};
@@ -243,8 +248,14 @@ FnsToEvaluate.L_h.household = @(h,sprime,s,z,e,kappa_j,Lhscale) kappa_j*exp(z+e)
 FnsToEvaluate.S.household = @(h,sprime,s,z,e) s; % Aggregate share holdings
 FnsToEvaluate.PensionSpending.household = @(h,sprime,s,z,e,pension,agej,Jr) (agej>=Jr)*pension; % Total spending on pensions
 FnsToEvaluate.PayrollTaxRevenue.household = @(h,sprime,s,z,e,agej,Jr,tau_l,w,kappa_j,Lhscale) (agej<Jr)*tau_l*w*kappa_j*exp(z+e)*Lhscale*h; % Total spending on pensions
-FnsToEvaluate.AccidentalBeqLeft.household = @(h,sprime,s,z,e,sj) sprime*(1-sj); % Accidental bequests left by people who die
-FnsToEvaluate.CapitalGainsTaxRevenue.household = @(h,sprime,s,z,e,tau_cg,P0,D,tau_d,r) tau_cg*(P0-(((1-tau_cg)*P0 + (1-tau_d)*D)/(1+r-tau_cg)))*s; % tau_cg*(P0-Plag)*s, but substitute P=Plag, and then substitute for P
+FnsToEvaluate.AccidentalBeq.household = @(h,sprime,s,z,e,sj,n) sprime*(1-sj)/(1+n); % Accidental bequests left by people who die, (possibly after estate taxes) and dilution to dependents
+FnsToEvaluate.CapitalGainsTaxRevenue.household = @(h,sprime,s,z,e,agej,P0,AccidentBeq,r,tau_cg,S_agej_first,S_agej_peak,S_agej_last) OLGModel14_HouseholdCapitalGainsFn(h,sprime,s,z,e,agej,P0,AccidentBeq,r,tau_cg,S_agej_first,S_agej_peak,S_agej_last);
+
+AgeConditionalStats=LifeCycleProfiles_FHorz_Case1_PType(StationaryDist,Policy,FnsToEvaluate.S,Params,n_d,n_a,n_z,N_j,Names_i,d_grid,a_grid,z_grid,simoptions);
+Params.S_agej_first=max(find(AgeConditionalStats.household.Mean>0.2,1,'first')-1,1);
+Params.S_agej_last=min(find(AgeConditionalStats.household.Mean>0.5,1,'last')+1,length(AgeConditionalStats.household.Mean));
+[~,Params.S_agej_peak]=max(AgeConditionalStats.household.Mean);
+
 % From firms
 FnsToEvaluate.Output.firm = @(d,kprime,k,z,w,alpha_k,alpha_l) z*(k^alpha_k)*((w/(alpha_l*z*(k^alpha_k)))^(1/(alpha_l-1)))^alpha_l; % Production function z*(k^alpha_k)*(l^alpha_l) (substituting for l)
 FnsToEvaluate.L_f.firm = @(d,kprime,k,z,w,alpha_k,alpha_l) (w/(alpha_l*z*(k^alpha_k)))^(1/(alpha_l-1)); % (effective units of) labor demanded by firm
@@ -314,8 +325,8 @@ title('Life Cycle Profile: Share holdings')
 %% Calculate some aggregates and print findings about them
 
 % Add consumption to the FnsToEvaluate
-FnsToEvaluate.Consumption.household=@(h,sprime,s,z,e,agej,Jr,pension,w,P0,D,kappa_j,AccidentBeq,r,tau_l,tau_d,tau_cg) OLGModel14_HouseholdConsumptionFn(h,sprime,s,z,e,agej,Jr,pension,w,P0,D,kappa_j,AccidentBeq,r,tau_l,tau_d,tau_cg);
-FnsToEvaluate.Income.household=@(h,sprime,s,z,e,agej,Jr,pension,w,P0,D,kappa_j,AccidentBeq,r,tau_l,tau_d,tau_cg) OLGModel14_HouseholdIncomeFn(h,sprime,s,z,e,agej,Jr,pension,w,P0,D,kappa_j,AccidentBeq,r,tau_l,tau_d,tau_cg);
+FnsToEvaluate.Consumption.household=@(h,sprime,s,z,e,agej,Jr,pension,w,P0,D,kappa_j,AccidentBeq,r,tau_l,tau_d,tau_cg,S_agej_first,S_agej_peak,S_agej_last) OLGModel14_HouseholdConsumptionFn(h,sprime,s,z,e,agej,Jr,pension,w,P0,D,kappa_j,AccidentBeq,r,tau_l,tau_d,tau_cg,S_agej_first,S_agej_peak,S_agej_last);
+FnsToEvaluate.Income.household=@(h,sprime,s,z,e,agej,Jr,pension,w,P0,D,kappa_j,AccidentBeq,r,tau_l,tau_d,tau_cg,S_agej_first,S_agej_peak,S_agej_last) OLGModel14_HouseholdIncomeFn(h,sprime,s,z,e,agej,Jr,pension,w,P0,D,kappa_j,AccidentBeq,r,tau_l,tau_d,tau_cg,S_agej_first,S_agej_peak,S_agej_last);
 
 AggVars=EvalFnOnAgentDist_AggVars_FHorz_Case1_PType(StationaryDist, Policy, FnsToEvaluate, Params, n_d, n_a, n_z,N_j, Names_i, d_grid, a_grid, z_grid,simoptions);
 
@@ -335,7 +346,7 @@ fprintf('Following are some aggregates of the model economy: \n')
 fprintf('Output: Y=%8.2f \n',AggVars.Output.Mean)
 fprintf('Aggregate TFP: Y=%8.2f \n',AggregateTFP)
 fprintf('Capital-Output ratio (firm side): K/Y=%8.2f \n',AggVars.K.Mean/Y)
-fprintf('Total asset value (HH side): P*S=%8.2f \n',P*AggVars.S.Mean)
+fprintf('Total asset value (HH side): P*S=%8.2f; n.b.: P*S/P0=%8.2f \n',P*AggVars.S.Mean,P*AggVars.S.Mean/Params.P0)
 fprintf('Total firm value (firm side): Value of firm=%8.2f \n',TotalValueOfFirms)
 fprintf('Consumption-Output ratio: C/Y=%8.2f \n',AggVars.Consumption.Mean/Y)
 fprintf('Government-to-Output ratio: G/Y=%8.2f \n', Params.G/Y)

--- a/OLGModel14.m
+++ b/OLGModel14.m
@@ -129,17 +129,18 @@ Params.TargetKdivL=2.03;
 % Some initial values/guesses for variables that will be determined in general eqm
 Params.pension=0.4; % Initial guess (this will be determined in general eqm)
 Params.w=1; % Wages, determines (household) labor supply and (firm) demand
-Params.AccidentBeq=0.02; % Accidental bequests (this is the lump sum transfer)
+Params.AccidentBeq=0.02; % Accidental bequests (this is the lump sum transfer received after capital gains taxes and dilution due to population growth, but before estate taxes)
 Params.G=0.1; % Government expenditure
 Params.firmbeta=1/(1+Params.r/(1-Params.tau_cg)); % 1/(1+r) but returns net of capital gains tax
 Params.D=0.2; % Dividends rate expected/received by households
-Params.P0=2.22; % This price is not 1 because we need price for older and younger agents to balance
+Params.P0=2.18; % This price is not 1 because we need price for older and younger agents to balance
 Params.Lhscale=0.22; % Scaling the household labor supply
 
 % We build a simple model of acquiring and disposing of stock over a lifetime
 Params.S_agej_first=20; % the age at which we start acquiring more stock than noise
-Params.S_agej_peak=Params.Jr+1; % the age of peak acquisition
-Params.S_agej_last=Params.J-10; % the age of final disposal
+Params.S_agej_peak_first=Params.Jr-1; % the age of first peak acquisition
+Params.S_agej_peak_last=Params.Jr+5; % the age of last peak acquisition
+Params.S_agej_last=Params.J-5; % the age of final disposal
 
 %% Grids for household
 
@@ -189,8 +190,8 @@ z_grid.firm=exp(z_grid.firm);
 % For households
 DiscountFactorParamNames.household={'beta','sj'};
 % Notice we use 'OLGModel14_HouseholdReturnFn'
-ReturnFn.household=@(h,sprime,s,z,e,sigma,psi,eta,agej,Jr,J,pension,w,P0,D,kappa_j,warmglow1,warmglow2,AccidentBeq,r,tau_l,tau_d,tau_cg,S_agej_first,S_agej_peak,S_agej_last)...
-    OLGModel14_HouseholdReturnFn(h,sprime,s,z,e,sigma,psi,eta,agej,Jr,J,pension,w,P0,D,kappa_j,warmglow1,warmglow2,AccidentBeq,r,tau_l,tau_d,tau_cg,S_agej_first,S_agej_peak,S_agej_last);
+ReturnFn.household=@(h,sprime,s,z,e,sigma,psi,eta,agej,Jr,J,pension,w,P0,D,kappa_j,warmglow1,warmglow2,AccidentBeq,r,tau_l,tau_d,tau_cg,S_agej_first,S_agej_peak_first,S_agej_peak_last,S_agej_last)...
+    OLGModel14_HouseholdReturnFn(h,sprime,s,z,e,sigma,psi,eta,agej,Jr,J,pension,w,P0,D,kappa_j,warmglow1,warmglow2,AccidentBeq,r,tau_l,tau_d,tau_cg,S_agej_first,S_agej_peak_first,S_agej_peak_last,S_agej_last);
 
 % For firms
 DiscountFactorParamNames.firm={'firmbeta'};
@@ -229,7 +230,7 @@ disp('Test StationaryDist')
 StationaryDist=StationaryDist_Case1_FHorz_PType(jequaloneDist,AgeWeightsParamNames,PTypeDistParamNames,Policy,n_d,n_a,n_z,N_j,Names_i,pi_z,Params,simoptions);
 
 %% General eqm variables
-GEPriceParamNames={'pension','AccidentBeq','G','w','firmbeta','D','P0'}; 
+GEPriceParamNames={'pension','G','w','firmbeta','D','P0'}; 
 % We don't need P
 % We can get P from the equation that defines r as the return to the mutual fund
 % 1+r = (P0 +(1-tau_d)D - tau_cg(P0-P))/Plag
@@ -248,13 +249,27 @@ FnsToEvaluate.L_h.household = @(h,sprime,s,z,e,kappa_j,Lhscale) kappa_j*exp(z+e)
 FnsToEvaluate.S.household = @(h,sprime,s,z,e) s; % Aggregate share holdings
 FnsToEvaluate.PensionSpending.household = @(h,sprime,s,z,e,pension,agej,Jr) (agej>=Jr)*pension; % Total spending on pensions
 FnsToEvaluate.PayrollTaxRevenue.household = @(h,sprime,s,z,e,agej,Jr,tau_l,w,kappa_j,Lhscale) (agej<Jr)*tau_l*w*kappa_j*exp(z+e)*Lhscale*h; % Total spending on pensions
-FnsToEvaluate.AccidentalBeq.household = @(h,sprime,s,z,e,sj,n) sprime*(1-sj)/(1+n); % Accidental bequests left by people who die, (possibly after estate taxes) and dilution to dependents
-FnsToEvaluate.CapitalGainsTaxRevenue.household = @(h,sprime,s,z,e,agej,P0,AccidentBeq,r,tau_cg,S_agej_first,S_agej_peak,S_agej_last) OLGModel14_HouseholdCapitalGainsFn(h,sprime,s,z,e,agej,P0,AccidentBeq,r,tau_cg,S_agej_first,S_agej_peak,S_agej_last);
+FnsToEvaluate.AccidentalBeq.household = @(h,sprime,s,z,e,agej,sj,n,P0,r,tau_cg,S_agej_first,S_agej_peak_first,S_agej_peak_last,S_agej_last) ... % Accidental bequests left by people who die, (possibly after estate taxes) and dilution to dependents
+    (sprime-OLGModel14_HouseholdCapitalGainsFn(h,sprime,s,z,e,agej,1,P0,0,r,tau_cg,S_agej_first,S_agej_peak_first,S_agej_peak_last,S_agej_last))*(1-sj)/(1+n);
+FnsToEvaluate.CapitalGainsTaxRevenue.household = @(h,sprime,s,z,e,agej,P0,AccidentBeq,r,tau_cg,S_agej_first,S_agej_peak_first,S_agej_peak_last,S_agej_last) OLGModel14_HouseholdCapitalGainsFn(h,sprime,s,z,e,agej,0,P0,AccidentBeq,r,tau_cg,S_agej_first,S_agej_peak_first,S_agej_peak_last,S_agej_last);
 
 AgeConditionalStats=LifeCycleProfiles_FHorz_Case1_PType(StationaryDist,Policy,FnsToEvaluate.S,Params,n_d,n_a,n_z,N_j,Names_i,d_grid,a_grid,z_grid,simoptions);
-Params.S_agej_first=max(find(AgeConditionalStats.household.Mean>0.2,1,'first')-1,1);
-Params.S_agej_last=min(find(AgeConditionalStats.household.Mean>0.5,1,'last')+1,length(AgeConditionalStats.household.Mean));
-[~,Params.S_agej_peak]=max(AgeConditionalStats.household.Mean);
+Params.S_agej_first=max(find(AgeConditionalStats.household.Mean>0.1,1,'first')-1,1);
+Params.S_agej_last=min(find(AgeConditionalStats.household.Mean>0.5,1,'last')+1,length(AgeConditionalStats.household.Mean)); % warmglow creates extra long tail we want to ignore
+[~,S_agej_peak]=max(AgeConditionalStats.household.Mean);
+S_peak_inflection_value=(1-1/Params.J)*AgeConditionalStats.household.Mean(S_agej_peak);
+for S_agej_peak_first=S_agej_peak:-1:Params.S_agej_first
+    if AgeConditionalStats.household.Mean(Params.S_agej_peak_first)<S_peak_inflection_value
+        break
+    end
+end
+Params.S_agej_peak_first=S_agej_peak_first;
+for S_agej_peak_last=Params.S_agej_last:-1:S_agej_peak
+    if AgeConditionalStats.household.Mean(Params.S_agej_peak_last-1)>S_peak_inflection_value
+        break
+    end
+end
+Params.S_agej_peak_last=S_agej_peak_last;
 
 % From firms
 FnsToEvaluate.Output.firm = @(d,kprime,k,z,w,alpha_k,alpha_l) z*(k^alpha_k)*((w/(alpha_l*z*(k^alpha_k)))^(1/(alpha_l-1)))^alpha_l; % Production function z*(k^alpha_k)*(l^alpha_l) (substituting for l)
@@ -268,7 +283,7 @@ FnsToEvaluate.CorpTaxRevenue.firm = @(d,kprime,k,z,w,delta,alpha_k,alpha_l,capad
 GeneralEqmEqns.sharemarket = @(S) S-1; % mass of all shares equals one
 GeneralEqmEqns.labormarket = @(L_h,L_f) L_h-L_f; % labor supply of households equals labor demand of firms
 GeneralEqmEqns.pensions = @(PensionSpending,PayrollTaxRevenue) PensionSpending-PayrollTaxRevenue; % Retirement benefits equal Payroll tax revenue: pension*fractionretired-tau*w*H
-GeneralEqmEqns.bequests = @(AccidentalBeqLeft,AccidentBeq,n) AccidentalBeqLeft/(1+n)-AccidentBeq; % Accidental bequests received equal accidental bequests left
+% GeneralEqmEqns.bequests = @(AccidentalBeqLeft,AccidentBeq,n) AccidentalBeqLeft/(1+n)-AccidentBeq; % Accidental bequests received equal accidental bequests left
 GeneralEqmEqns.govbudget = @(G,tau_d,D,CapitalGainsTaxRevenue,CorpTaxRevenue) G-tau_d*D-CapitalGainsTaxRevenue-CorpTaxRevenue; % G is equal to the target, GdivYtarget*Y
 GeneralEqmEqns.firmdiscounting = @(firmbeta,r,tau_cg) firmbeta-1/(1+r/(1-tau_cg)); % Firms discount rate is related to market return rate
 GeneralEqmEqns.dividends = @(D,DividendPaid) D-DividendPaid; % That the dividend households receive equals that which firms give
@@ -291,6 +306,8 @@ AggVars.S.Mean
 fprintf('Check: ShareIssuance GE condition \n')
 Params.P0-((((1-Params.tau_cg)*Params.P0 + (1-Params.tau_d)*Params.D)/(1+Params.r-Params.tau_cg))-AggVars.S.Mean)
 
+% Update estimate to value from initial stationary distribution
+Params.AccidentBeq=AggVars.AccidentalBeq.household.Mean;
 
 %% Solve for the General Equilibrium
 % heteroagentoptions.fminalgo=4 % CMA-ES algorithm 
@@ -300,7 +317,7 @@ p_eqm=HeteroAgentStationaryEqm_Case1_FHorz_PType(n_d, n_a, n_z, N_j, Names_i, []
 % p_eqm contains the general equilibrium parameter values
 % Put this into Params so we can calculate things about the initial equilibrium
 Params.pension=p_eqm.pension;
-Params.AccidentBeq=p_eqm.AccidentBeq;
+% Params.AccidentBeq=p_eqm.AccidentBeq;
 Params.G=p_eqm.G;
 Params.w=p_eqm.w;
 Params.firmbeta=p_eqm.firmbeta;
@@ -325,8 +342,8 @@ title('Life Cycle Profile: Share holdings')
 %% Calculate some aggregates and print findings about them
 
 % Add consumption to the FnsToEvaluate
-FnsToEvaluate.Consumption.household=@(h,sprime,s,z,e,agej,Jr,pension,w,P0,D,kappa_j,AccidentBeq,r,tau_l,tau_d,tau_cg,S_agej_first,S_agej_peak,S_agej_last) OLGModel14_HouseholdConsumptionFn(h,sprime,s,z,e,agej,Jr,pension,w,P0,D,kappa_j,AccidentBeq,r,tau_l,tau_d,tau_cg,S_agej_first,S_agej_peak,S_agej_last);
-FnsToEvaluate.Income.household=@(h,sprime,s,z,e,agej,Jr,pension,w,P0,D,kappa_j,AccidentBeq,r,tau_l,tau_d,tau_cg,S_agej_first,S_agej_peak,S_agej_last) OLGModel14_HouseholdIncomeFn(h,sprime,s,z,e,agej,Jr,pension,w,P0,D,kappa_j,AccidentBeq,r,tau_l,tau_d,tau_cg,S_agej_first,S_agej_peak,S_agej_last);
+FnsToEvaluate.Consumption.household=@(h,sprime,s,z,e,agej,Jr,pension,w,P0,D,kappa_j,AccidentBeq,r,tau_l,tau_d,tau_cg,S_agej_first,S_agej_peak_first,S_agej_peak_last,S_agej_last) OLGModel14_HouseholdConsumptionFn(h,sprime,s,z,e,agej,Jr,pension,w,P0,D,kappa_j,AccidentBeq,r,tau_l,tau_d,tau_cg,S_agej_first,S_agej_peak_first,S_agej_peak_last,S_agej_last);
+FnsToEvaluate.Income.household=@(h,sprime,s,z,e,agej,Jr,pension,w,P0,D,kappa_j,AccidentBeq,r,tau_l,tau_d,tau_cg,S_agej_first,S_agej_peak_first,S_agej_peak_last,S_agej_last) OLGModel14_HouseholdIncomeFn(h,sprime,s,z,e,agej,Jr,pension,w,P0,D,kappa_j,AccidentBeq,r,tau_l,tau_d,tau_cg,S_agej_first,S_agej_peak_first,S_agej_peak_last,S_agej_last);
 
 AggVars=EvalFnOnAgentDist_AggVars_FHorz_Case1_PType(StationaryDist, Policy, FnsToEvaluate, Params, n_d, n_a, n_z,N_j, Names_i, d_grid, a_grid, z_grid,simoptions);
 

--- a/OLGModel14_HouseholdCapitalGainsFn.m
+++ b/OLGModel14_HouseholdCapitalGainsFn.m
@@ -1,4 +1,4 @@
-function c=OLGModel14_HouseholdConsumptionFn(h,sprime,s,z,e,agej,Jr,pension,w,P0,D,kappa_j,AccidentBeq,r,tau_l,tau_d,tau_cg,S_agej_first,S_agej_peak,S_agej_last)
+function cg=OLGModel14_HouseholdCapitalGainsFn(h,sprime,s,z,e,agej,P0,AccidentBeq,r,tau_cg,S_agej_first,S_agej_peak,S_agej_last)
 % Replace assets with 'share holdings'
 % Get rid of progressive taxes
 % Add Lhnormalize
@@ -9,7 +9,6 @@ function c=OLGModel14_HouseholdConsumptionFn(h,sprime,s,z,e,agej,Jr,pension,w,P0
 % Plag=P;
 % And thus we have P=((1-tau_cg)*P0 + (1-tau_d)*D)/(1+r-tau_cg);
 
-P=P0;
 if sprime>=s
     Plag=P0; % We are holding or buying, so no capital gains
 else
@@ -24,13 +23,6 @@ else
     end
 end
 
-if agej<Jr % If working age
-    %consumption = labor income + accidental bequest + share holdings (including dividend) - capital gains tax - next period share holdings
-    c=(1-tau_l)*w*kappa_j*exp(z+e)*h+((1-tau_d)*D+P0)*(s+AccidentBeq) -tau_cg*(P0-Plag)*(s+AccidentBeq)-P*sprime; 
-else % Retirement
-    c=pension+((1-tau_d)*D+P0)*(s+AccidentBeq) -tau_cg*(P0-Plag)*(s+AccidentBeq) - P*sprime;
-end
-
-% Notice that sprime>=0 is being implicitly imposed by grid on s
+cg=tau_cg*(P0-Plag)*(s+AccidentBeq);
 
 end

--- a/OLGModel14_HouseholdCapitalGainsFn.m
+++ b/OLGModel14_HouseholdCapitalGainsFn.m
@@ -16,11 +16,16 @@ else
     if agej<=S_agej_peak_first
         agej_bought=agej-1;
         Plag=P0*(1-2*r); % Dispose of shares presumably acquired recently
+    elseif S_agej_peak_last==S_agej_last % Bulk liquidation
+        % Sell all remaining shares from first acquisition to buy-point (using geometric mean to average acquisition cost)
+        agej_bought=S_agej_peak_first-sqrt(S_agej_peak_first-S_agej_first);
+        Plag=P0*(1-2*r)^(agej-agej_bought);
+        at_death=0; % Don't bulk liquidate twice
     else
         % Estimate where we are past peak accumulation and mirror around to
         % proportional acquisition point
         agej_selling_pct=(agej-S_agej_peak_last)/(S_agej_last-S_agej_peak_last);
-        agej_bought=S_agej_peak_first-ceil(agej_selling_pct*(S_agej_peak_first-S_agej_first));
+        agej_bought=S_agej_peak_first-agej_selling_pct*(S_agej_peak_first-S_agej_first);
         Plag=P0*(1-2*r)^(agej-agej_bought);
     end
     cg=tau_cg*(P0-Plag)*(s+AccidentBeq-sprime);

--- a/OLGModel14_HouseholdCapitalGainsFn.m
+++ b/OLGModel14_HouseholdCapitalGainsFn.m
@@ -26,9 +26,11 @@ else
     cg=tau_cg*(P0-Plag)*(s+AccidentBeq-sprime);
 end
 
-
 if at_death && agej_bought>=S_agej_first
     % Sell all remaining shares from first acquisition to buy-point (using geometric mean to average acquisition cost)
     Plag=P0*(1-2*r)^(agej_bought-sqrt(agej_bought-S_agej_first));
     cg=cg+tau_cg*(P0-Plag)*sprime;
+end
+
+
 end

--- a/OLGModel14_HouseholdCapitalGainsFn.m
+++ b/OLGModel14_HouseholdCapitalGainsFn.m
@@ -1,4 +1,4 @@
-function cg=OLGModel14_HouseholdCapitalGainsFn(h,sprime,s,z,e,agej,P0,AccidentBeq,r,tau_cg,S_agej_first,S_agej_peak,S_agej_last)
+function cg=OLGModel14_HouseholdCapitalGainsFn(h,sprime,s,z,e,agej,at_death,P0,AccidentBeq,r,tau_cg,S_agej_first,S_agej_peak_first,S_agej_peak_last,S_agej_last)
 % Replace assets with 'share holdings'
 % Get rid of progressive taxes
 % Add Lhnormalize
@@ -10,19 +10,25 @@ function cg=OLGModel14_HouseholdCapitalGainsFn(h,sprime,s,z,e,agej,P0,AccidentBe
 % And thus we have P=((1-tau_cg)*P0 + (1-tau_d)*D)/(1+r-tau_cg);
 
 if sprime>=s
-    Plag=P0; % We are holding or buying, so no capital gains
+    agej_bought=agej;
+    cg=0; % We are holding or buying, so no capital gains
 else
-    if agej<=S_agej_peak
+    if agej<=S_agej_peak_first
+        agej_bought=agej-1;
         Plag=P0*(1-2*r); % Dispose of shares presumably acquired recently
     else
         % Estimate where we are past peak accumulation and mirror around to
         % proportional acquisition point
-        agej_selling_pct=(agej-S_agej_peak)/(S_agej_last-S_agej_peak);
-        agej_bought=S_agej_peak-ceil(agej_selling_pct*(S_agej_peak-S_agej_first));
+        agej_selling_pct=(agej-S_agej_peak_last)/(S_agej_last-S_agej_peak_last);
+        agej_bought=S_agej_peak_first-ceil(agej_selling_pct*(S_agej_peak_first-S_agej_first));
         Plag=P0*(1-2*r)^(agej-agej_bought);
     end
+    cg=tau_cg*(P0-Plag)*(s+AccidentBeq-sprime);
 end
 
-cg=tau_cg*(P0-Plag)*(s+AccidentBeq);
 
+if at_death && agej_bought>=S_agej_first
+    % Sell all remaining shares from first acquisition to buy-point (using geometric mean to average acquisition cost)
+    Plag=P0*(1-2*r)^(agej_bought-sqrt(agej_bought-S_agej_first));
+    cg=cg+tau_cg*(P0-Plag)*sprime;
 end

--- a/OLGModel14_HouseholdCapitalGainsFn.m
+++ b/OLGModel14_HouseholdCapitalGainsFn.m
@@ -16,6 +16,10 @@ else
     if agej<=S_agej_peak_first
         agej_bought=agej-1;
         Plag=P0*(1-2*r); % Dispose of shares presumably acquired recently
+    elseif agej<S_agej_peak_last
+        % We have been holding since peak acquisition
+        agej_bought=S_agej_peak_first;
+        Plag=P0*(1-2*r)^(ypp*(agej-agej_bought));
     elseif S_agej_peak_last==S_agej_last % Bulk liquidation
         % Sell all remaining shares from first acquisition to buy-point (using geometric mean to average acquisition cost)
         agej_bought=S_agej_peak_first-sqrt(S_agej_peak_first-S_agej_first);

--- a/OLGModel14_HouseholdCapitalGainsFn.m
+++ b/OLGModel14_HouseholdCapitalGainsFn.m
@@ -19,7 +19,7 @@ else
     elseif agej<S_agej_peak_last
         % We have been holding since peak acquisition
         agej_bought=S_agej_peak_first;
-        Plag=P0*(1-2*r)^(ypp*(agej-agej_bought));
+        Plag=P0*(1-2*r)^(agej-agej_bought);
     elseif S_agej_peak_last==S_agej_last % Bulk liquidation
         % Sell all remaining shares from first acquisition to buy-point (using geometric mean to average acquisition cost)
         agej_bought=S_agej_peak_first-sqrt(S_agej_peak_first-S_agej_first);

--- a/OLGModel14_HouseholdConsumptionFn.m
+++ b/OLGModel14_HouseholdConsumptionFn.m
@@ -18,11 +18,15 @@ else
     if agej<=S_agej_peak_first
         agej_bought=agej-1;
         Plag=P0*(1-2*r); % Dispose of shares presumably acquired recently
+    elseif S_agej_peak_last==S_agej_last % Bulk liquidation
+        % Sell all remaining shares from first acquisition to buy-point (using geometric mean to average acquisition cost)
+        agej_bought=S_agej_peak_first-sqrt(S_agej_peak_first-S_agej_first);
+        Plag=P0*(1-2*r)^(agej-agej_bought);
     else
         % Estimate where we are past peak accumulation and mirror around to
         % proportional acquisition point
         agej_selling_pct=(agej-S_agej_peak_last)/(S_agej_last-S_agej_peak_last);
-        agej_bought=S_agej_peak_first-ceil(agej_selling_pct*(S_agej_peak_first-S_agej_first));
+        agej_bought=S_agej_peak_first-agej_selling_pct*(S_agej_peak_first-S_agej_first);
         Plag=P0*(1-2*r)^(agej-agej_bought);
     end
     cg=tau_cg*(P0-Plag)*(s+AccidentBeq-sprime);

--- a/OLGModel14_HouseholdConsumptionFn.m
+++ b/OLGModel14_HouseholdConsumptionFn.m
@@ -21,7 +21,7 @@ else
     elseif agej<S_agej_peak_last
         % We have been holding since peak acquisition
         agej_bought=S_agej_peak_first;
-        Plag=P0*(1-2*r)^(ypp*(agej-agej_bought));
+        Plag=P0*(1-2*r)^(agej-agej_bought);
     elseif S_agej_peak_last==S_agej_last % Bulk liquidation
         % Sell all remaining shares from first acquisition to buy-point (using geometric mean to average acquisition cost)
         agej_bought=S_agej_peak_first-sqrt(S_agej_peak_first-S_agej_first);

--- a/OLGModel14_HouseholdConsumptionFn.m
+++ b/OLGModel14_HouseholdConsumptionFn.m
@@ -1,4 +1,4 @@
-function c=OLGModel14_HouseholdConsumptionFn(h,sprime,s,z,e,agej,Jr,pension,w,P0,D,kappa_j,AccidentBeq,r,tau_l,tau_d,tau_cg,S_agej_first,S_agej_peak,S_agej_last)
+function c=OLGModel14_HouseholdConsumptionFn(h,sprime,s,z,e,agej,Jr,pension,w,P0,D,kappa_j,AccidentBeq,r,tau_l,tau_d,tau_cg,S_agej_first,S_agej_peak_first,S_agej_peak_last,S_agej_last)
 % Replace assets with 'share holdings'
 % Get rid of progressive taxes
 % Add Lhnormalize
@@ -11,24 +11,28 @@ function c=OLGModel14_HouseholdConsumptionFn(h,sprime,s,z,e,agej,Jr,pension,w,P0
 
 P=P0;
 if sprime>=s
+    agej_bought=agej;
     Plag=P0; % We are holding or buying, so no capital gains
+    cg=0;
 else
-    if agej<=S_agej_peak
+    if agej<=S_agej_peak_first
+        agej_bought=agej-1;
         Plag=P0*(1-2*r); % Dispose of shares presumably acquired recently
     else
         % Estimate where we are past peak accumulation and mirror around to
         % proportional acquisition point
-        agej_selling_pct=(agej-S_agej_peak)/(S_agej_last-S_agej_peak);
-        agej_bought=S_agej_peak-ceil(agej_selling_pct*(S_agej_peak-S_agej_first));
+        agej_selling_pct=(agej-S_agej_peak_last)/(S_agej_last-S_agej_peak_last);
+        agej_bought=S_agej_peak_first-ceil(agej_selling_pct*(S_agej_peak_first-S_agej_first));
         Plag=P0*(1-2*r)^(agej-agej_bought);
     end
+    cg=tau_cg*(P0-Plag)*(s+AccidentBeq-sprime);
 end
 
 if agej<Jr % If working age
     %consumption = labor income + accidental bequest + share holdings (including dividend) - capital gains tax - next period share holdings
-    c=(1-tau_l)*w*kappa_j*exp(z+e)*h+((1-tau_d)*D+P0)*(s+AccidentBeq) -tau_cg*(P0-Plag)*(s+AccidentBeq)-P*sprime; 
+    c=(1-tau_l)*w*kappa_j*exp(z+e)*h+((1-tau_d)*D+P0)*(s+AccidentBeq) -cg -P*sprime; 
 else % Retirement
-    c=pension+((1-tau_d)*D+P0)*(s+AccidentBeq) -tau_cg*(P0-Plag)*(s+AccidentBeq) - P*sprime;
+    c=pension+((1-tau_d)*D+P0)*(s+AccidentBeq) -cg -P*sprime;
 end
 
 % Notice that sprime>=0 is being implicitly imposed by grid on s

--- a/OLGModel14_HouseholdConsumptionFn.m
+++ b/OLGModel14_HouseholdConsumptionFn.m
@@ -18,6 +18,10 @@ else
     if agej<=S_agej_peak_first
         agej_bought=agej-1;
         Plag=P0*(1-2*r); % Dispose of shares presumably acquired recently
+    elseif agej<S_agej_peak_last
+        % We have been holding since peak acquisition
+        agej_bought=S_agej_peak_first;
+        Plag=P0*(1-2*r)^(ypp*(agej-agej_bought));
     elseif S_agej_peak_last==S_agej_last % Bulk liquidation
         % Sell all remaining shares from first acquisition to buy-point (using geometric mean to average acquisition cost)
         agej_bought=S_agej_peak_first-sqrt(S_agej_peak_first-S_agej_first);

--- a/OLGModel14_HouseholdIncomeFn.m
+++ b/OLGModel14_HouseholdIncomeFn.m
@@ -1,4 +1,4 @@
-function income=OLGModel14_HouseholdIncomeFn(h,sprime,s,z,e,agej,Jr,pension,w,P0,D,kappa_j,AccidentBeq,r,tau_l,tau_d,tau_cg,S_agej_first,S_agej_peak,S_agej_last)
+function income=OLGModel14_HouseholdIncomeFn(h,sprime,s,z,e,agej,Jr,pension,w,P0,D,kappa_j,AccidentBeq,r,tau_l,tau_d,tau_cg,S_agej_first,S_agej_peak_first,S_agej_peak_last,S_agej_last)
 % Replace assets with 'share holdings'
 % Get rid of progressive taxes
 % Add Lhnormalize
@@ -10,25 +10,29 @@ function income=OLGModel14_HouseholdIncomeFn(h,sprime,s,z,e,agej,Jr,pension,w,P0
 % And thus we have P=((1-tau_cg)*P0 + (1-tau_d)*D)/(1+r-tau_cg);
 
 if sprime>=s
+    agej_bought=agej;
     Plag=P0; % We are holding or buying, so no capital gains
+    cg=0;
 else
-    if agej<=S_agej_peak
+    if agej<=S_agej_peak_first
+        agej_bought=agej-1;
         Plag=P0*(1-2*r); % Dispose of shares presumably acquired recently
     else
         % Estimate where we are past peak accumulation and mirror around to
         % proportional acquisition point
-        agej_selling_pct=(agej-S_agej_peak)/(S_agej_last-S_agej_peak);
-        agej_bought=S_agej_peak-ceil(agej_selling_pct*(S_agej_peak-S_agej_first));
+        agej_selling_pct=(agej-S_agej_peak_last)/(S_agej_last-S_agej_peak_last);
+        agej_bought=S_agej_peak_first-ceil(agej_selling_pct*(S_agej_peak_first-S_agej_first));
         Plag=P0*(1-2*r)^(agej-agej_bought);
     end
+    cg=tau_cg*(P0-Plag)*(s+AccidentBeq-sprime);
 end
 
 if agej<Jr % If working age
     %consumption = labor income + accidental bequest + share holdings (including dividend) - capital gains tax - next period share holdings
     % income just is consumption but without subtracting the term for next period share holdings (-P*sprime)
-    income=(1-tau_l)*w*kappa_j*exp(z+e)*h+((1-tau_d)*D+P0)*(s+AccidentBeq) -tau_cg*(P0-Plag)*(s+AccidentBeq); 
+    income=(1-tau_l)*w*kappa_j*exp(z+e)*h+((1-tau_d)*D+P0)*(s+AccidentBeq) -cg; 
 else % Retirement
-    income=pension+((1-tau_d)*D+P0)*(s+AccidentBeq) -tau_cg*(P0-Plag)*(s+AccidentBeq);
+    income=pension+((1-tau_d)*D+P0)*(s+AccidentBeq) -cg;
 end
 
 % Notice that sprime>=0 is being implicitly imposed by grid on s

--- a/OLGModel14_HouseholdIncomeFn.m
+++ b/OLGModel14_HouseholdIncomeFn.m
@@ -20,7 +20,7 @@ else
     elseif agej<S_agej_peak_last
         % We have been holding since peak acquisition
         agej_bought=S_agej_peak_first;
-        Plag=P0*(1-2*r)^(ypp*(agej-agej_bought));
+        Plag=P0*(1-2*r)^(agej-agej_bought);
     elseif S_agej_peak_last==S_agej_last % Bulk liquidation
         % Sell all remaining shares from first acquisition to buy-point (using geometric mean to average acquisition cost)
         agej_bought=S_agej_peak_first-sqrt(S_agej_peak_first-S_agej_first);

--- a/OLGModel14_HouseholdIncomeFn.m
+++ b/OLGModel14_HouseholdIncomeFn.m
@@ -17,11 +17,15 @@ else
     if agej<=S_agej_peak_first
         agej_bought=agej-1;
         Plag=P0*(1-2*r); % Dispose of shares presumably acquired recently
+    elseif S_agej_peak_last==S_agej_last % Bulk liquidation
+        % Sell all remaining shares from first acquisition to buy-point (using geometric mean to average acquisition cost)
+        agej_bought=S_agej_peak_first-sqrt(S_agej_peak_first-S_agej_first);
+        Plag=P0*(1-2*r)^(agej-agej_bought);
     else
         % Estimate where we are past peak accumulation and mirror around to
         % proportional acquisition point
         agej_selling_pct=(agej-S_agej_peak_last)/(S_agej_last-S_agej_peak_last);
-        agej_bought=S_agej_peak_first-ceil(agej_selling_pct*(S_agej_peak_first-S_agej_first));
+        agej_bought=S_agej_peak_first-agej_selling_pct*(S_agej_peak_first-S_agej_first);
         Plag=P0*(1-2*r)^(agej-agej_bought);
     end
     cg=tau_cg*(P0-Plag)*(s+AccidentBeq-sprime);

--- a/OLGModel14_HouseholdIncomeFn.m
+++ b/OLGModel14_HouseholdIncomeFn.m
@@ -1,4 +1,4 @@
-function income=OLGModel14_HouseholdIncomeFn(h,sprime,s,z,e,agej,Jr,pension,w,P0,D,kappa_j,AccidentBeq,r,tau_l,tau_d,tau_cg)
+function income=OLGModel14_HouseholdIncomeFn(h,sprime,s,z,e,agej,Jr,pension,w,P0,D,kappa_j,AccidentBeq,r,tau_l,tau_d,tau_cg,S_agej_first,S_agej_peak,S_agej_last)
 % Replace assets with 'share holdings'
 % Get rid of progressive taxes
 % Add Lhnormalize
@@ -7,10 +7,21 @@ function income=OLGModel14_HouseholdIncomeFn(h,sprime,s,z,e,agej,Jr,pension,w,P0
 % 1+r = (P0 +(1-tau_d)D - tau_cg(P0-P))/Plag
 % We are looking at stationary general eqm, so
 % Plag=P;
-% And thus we have
-P=((1-tau_cg)*P0 + (1-tau_d)*D)/(1+r-tau_cg);
+% And thus we have P=((1-tau_cg)*P0 + (1-tau_d)*D)/(1+r-tau_cg);
 
-Plag=P; % As stationary general eqm
+if sprime>=s
+    Plag=P0; % We are holding or buying, so no capital gains
+else
+    if agej<=S_agej_peak
+        Plag=P0*(1-2*r); % Dispose of shares presumably acquired recently
+    else
+        % Estimate where we are past peak accumulation and mirror around to
+        % proportional acquisition point
+        agej_selling_pct=(agej-S_agej_peak)/(S_agej_last-S_agej_peak);
+        agej_bought=S_agej_peak-ceil(agej_selling_pct*(S_agej_peak-S_agej_first));
+        Plag=P0*(1-2*r)^(agej-agej_bought);
+    end
+end
 
 if agej<Jr % If working age
     %consumption = labor income + accidental bequest + share holdings (including dividend) - capital gains tax - next period share holdings

--- a/OLGModel14_HouseholdIncomeFn.m
+++ b/OLGModel14_HouseholdIncomeFn.m
@@ -17,6 +17,10 @@ else
     if agej<=S_agej_peak_first
         agej_bought=agej-1;
         Plag=P0*(1-2*r); % Dispose of shares presumably acquired recently
+    elseif agej<S_agej_peak_last
+        % We have been holding since peak acquisition
+        agej_bought=S_agej_peak_first;
+        Plag=P0*(1-2*r)^(ypp*(agej-agej_bought));
     elseif S_agej_peak_last==S_agej_last % Bulk liquidation
         % Sell all remaining shares from first acquisition to buy-point (using geometric mean to average acquisition cost)
         agej_bought=S_agej_peak_first-sqrt(S_agej_peak_first-S_agej_first);

--- a/OLGModel14_HouseholdReturnFn.m
+++ b/OLGModel14_HouseholdReturnFn.m
@@ -32,6 +32,10 @@ else
     if agej<=S_agej_peak_first
         agej_bought=agej-1;
         Plag=P0*(1-2*r); % Dispose of shares presumably acquired recently
+    elseif agej<S_agej_peak_last
+        % We have been holding since peak acquisition
+        agej_bought=S_agej_peak_first;
+        Plag=P0*(1-2*r)^(ypp*(agej-agej_bought));
     elseif S_agej_peak_last==S_agej_last % Bulk liquidation
         % Sell all remaining shares from first acquisition to buy-point (using geometric mean to average acquisition cost)
         agej_bought=S_agej_peak_first-sqrt(S_agej_peak_first-S_agej_first);

--- a/OLGModel14_HouseholdReturnFn.m
+++ b/OLGModel14_HouseholdReturnFn.m
@@ -1,16 +1,42 @@
-function F=OLGModel14_HouseholdReturnFn(h,sprime,s,z,e,sigma,psi,eta,agej,Jr,J,pension,w,P0,D,kappa_j,warmglow1,warmglow2,AccidentBeq,r,tau_l,tau_d,tau_cg)
+function F=OLGModel14_HouseholdReturnFn(h,sprime,s,z,e,sigma,psi,eta,agej,Jr,J,pension,w,P0,D,kappa_j,warmglow1,warmglow2,AccidentBeq,r,tau_l,tau_d,tau_cg,S_agej_first,S_agej_peak,S_agej_last)
 % Replace assets with 'share holdings'
 % Get rid of progressive taxes
 % Add Lhnormalize
+
 
 % We can get P from the equation that defines r as the return to the mutual fund
 % 1+r = (P0 +(1-tau_d)D - tau_cg(P0-P))/Plag
 % We are looking at stationary general eqm, so
 % Plag=P;
-% And thus we have
-P=((1-tau_cg)*P0 + (1-tau_d)*D)/(1+r-tau_cg);
+% And thus we have P=((1-tau_cg)*P0 + (1-tau_d)*D)/(1+r-tau_cg);
 
-Plag=P; % As stationary general eqm
+% But in fact the price does not meaningfully represent the acquisition
+% cost by a younger generation that is now older in this stationary
+% distribution.  However, we can use the history of acquisition and
+% disposals to impute when agents are buying and selling, and thus what
+% capital gains they should pay.  We imagine that stocks earn 2x the
+% risk-free rate of return (i.e., 2*r) and that if we are selling before
+% they peak, we are selling recently acquired stocks, whereas if we are
+% selling at or after the peak of acquisition, we are selling long-term
+% gains in a LIFO fashion.
+
+% We take P0 as the price of the current stationary distribution, and we
+% back-calculate what the price Plag may have been in the past.
+
+P=P0;
+if sprime>=s
+    Plag=P0; % We are holding or buying, so no capital gains
+else
+    if agej<=S_agej_peak
+        Plag=P0*(1-2*r); % Dispose of shares presumably acquired recently
+    else
+        % Estimate where we are past peak accumulation and mirror around to
+        % proportional acquisition point
+        agej_selling_pct=(agej-S_agej_peak)/(S_agej_last-S_agej_peak);
+        agej_bought=S_agej_peak-ceil(agej_selling_pct*(S_agej_peak-S_agej_first));
+        Plag=P0*(1-2*r)^(agej-agej_bought);
+    end
+end
 
 F=-Inf;
 if agej<Jr % If working age

--- a/OLGModel14_HouseholdReturnFn.m
+++ b/OLGModel14_HouseholdReturnFn.m
@@ -32,11 +32,15 @@ else
     if agej<=S_agej_peak_first
         agej_bought=agej-1;
         Plag=P0*(1-2*r); % Dispose of shares presumably acquired recently
+    elseif S_agej_peak_last==S_agej_last % Bulk liquidation
+        % Sell all remaining shares from first acquisition to buy-point (using geometric mean to average acquisition cost)
+        agej_bought=S_agej_peak_first-sqrt(S_agej_peak_first-S_agej_first);
+        Plag=P0*(1-2*r)^(agej-agej_bought);
     else
         % Estimate where we are past peak accumulation and mirror around to
         % proportional acquisition point
         agej_selling_pct=(agej-S_agej_peak_last)/(S_agej_last-S_agej_peak_last);
-        agej_bought=S_agej_peak_first-ceil(agej_selling_pct*(S_agej_peak_first-S_agej_first));
+        agej_bought=S_agej_peak_first-agej_selling_pct*(S_agej_peak_first-S_agej_first);
         Plag=P0*(1-2*r)^(agej-agej_bought);
     end
     cg=tau_cg*(P0-Plag)*(s+AccidentBeq-sprime);

--- a/OLGModel14_HouseholdReturnFn.m
+++ b/OLGModel14_HouseholdReturnFn.m
@@ -35,7 +35,7 @@ else
     elseif agej<S_agej_peak_last
         % We have been holding since peak acquisition
         agej_bought=S_agej_peak_first;
-        Plag=P0*(1-2*r)^(ypp*(agej-agej_bought));
+        Plag=P0*(1-2*r)^(agej-agej_bought);
     elseif S_agej_peak_last==S_agej_last % Bulk liquidation
         % Sell all remaining shares from first acquisition to buy-point (using geometric mean to average acquisition cost)
         agej_bought=S_agej_peak_first-sqrt(S_agej_peak_first-S_agej_first);

--- a/OLGModel14_HouseholdReturnFn.m
+++ b/OLGModel14_HouseholdReturnFn.m
@@ -1,4 +1,4 @@
-function F=OLGModel14_HouseholdReturnFn(h,sprime,s,z,e,sigma,psi,eta,agej,Jr,J,pension,w,P0,D,kappa_j,warmglow1,warmglow2,AccidentBeq,r,tau_l,tau_d,tau_cg,S_agej_first,S_agej_peak,S_agej_last)
+function F=OLGModel14_HouseholdReturnFn(h,sprime,s,z,e,sigma,psi,eta,agej,Jr,J,pension,w,P0,D,kappa_j,warmglow1,warmglow2,AccidentBeq,r,tau_l,tau_d,tau_cg,S_agej_first,S_agej_peak_first,S_agej_peak_last,S_agej_last)
 % Replace assets with 'share holdings'
 % Get rid of progressive taxes
 % Add Lhnormalize
@@ -25,25 +25,29 @@ function F=OLGModel14_HouseholdReturnFn(h,sprime,s,z,e,sigma,psi,eta,agej,Jr,J,p
 
 P=P0;
 if sprime>=s
+    agej_bought=agej;
     Plag=P0; % We are holding or buying, so no capital gains
+    cg=0;
 else
-    if agej<=S_agej_peak
+    if agej<=S_agej_peak_first
+        agej_bought=agej-1;
         Plag=P0*(1-2*r); % Dispose of shares presumably acquired recently
     else
         % Estimate where we are past peak accumulation and mirror around to
         % proportional acquisition point
-        agej_selling_pct=(agej-S_agej_peak)/(S_agej_last-S_agej_peak);
-        agej_bought=S_agej_peak-ceil(agej_selling_pct*(S_agej_peak-S_agej_first));
+        agej_selling_pct=(agej-S_agej_peak_last)/(S_agej_last-S_agej_peak_last);
+        agej_bought=S_agej_peak_first-ceil(agej_selling_pct*(S_agej_peak_first-S_agej_first));
         Plag=P0*(1-2*r)^(agej-agej_bought);
     end
+    cg=tau_cg*(P0-Plag)*(s+AccidentBeq-sprime);
 end
 
 F=-Inf;
 if agej<Jr % If working age
     %consumption = labor income + accidental bequest + share holdings (including dividend) - capital gains tax - next period share holdings
-    c=(1-tau_l)*w*kappa_j*exp(z+e)*h+((1-tau_d)*D+P0)*(s+AccidentBeq) -tau_cg*(P0-Plag)*(s+AccidentBeq)-P*sprime; 
+    c=(1-tau_l)*w*kappa_j*exp(z+e)*h+((1-tau_d)*D+P0)*(s+AccidentBeq) -cg -P*sprime; 
 else % Retirement
-    c=pension+((1-tau_d)*D+P0)*(s+AccidentBeq) -tau_cg*(P0-Plag)*(s+AccidentBeq) - P*sprime;
+    c=pension+((1-tau_d)*D+P0)*(s+AccidentBeq) -cg -P*sprime;
 end
 
 if c>0


### PR DESCRIPTION
These changes use a simple last-in/first-out model of stock acquisition and disposal. If an agent should choose to sell stock before max acquisition period is upon them, we presume it's hardship due to a shock, and that they basically liquidate stock acquired the previous period.
For stocks sold peak acquisition, we calculate the distance from the agent's age to the peak and presume they are selling stock purchased proportionally prior to the peak acquisition period. This could be improved by noticing whether there's a wide peak (in which case we should center the peak).  But the general concept is to capture the taxes that fall on a symmetric buy/sell pattern. 
We have to adjust the initial price of the stock because older agents who acquired the stock when they were younger buy in at a very low cost (relatively speaking).  The price is selected so that the stock value balances to 1, meaning younger agents pay above 1 and older agents paid below one when they "bought" the stock they hold.